### PR TITLE
Add social media preview card meta tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,10 +5,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta property="og:title" content="LessOnline 2026 — Save the Date">
   <meta property="og:description" content="June 5–7, 2026 | Lighthaven, Berkeley CA">
+  <meta property="og:image" content="https://res.cloudinary.com/lesswrong-2-0/image/upload/Screenshot_2026-02-10_at_3.02.53_PM_vi31er">
   <meta property="og:url" content="https://less.online/">
-  <meta name="twitter:card" content="summary">
+  <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="LessOnline 2026 — Save the Date">
   <meta name="twitter:description" content="June 5–7, 2026 | Lighthaven, Berkeley CA">
+  <meta name="twitter:image" content="https://res.cloudinary.com/lesswrong-2-0/image/upload/Screenshot_2026-02-10_at_3.02.53_PM_vi31er">
   <link rel="shortcut icon" type="image/jpg" href="/public/LessOnlineLogo.png" />
   <title>LessOnline 2026</title>
   <style>


### PR DESCRIPTION
Added og:image and twitter:image pointing to Cloudinary-hosted card. Upgraded twitter:card from summary to summary_large_image for bigger preview.